### PR TITLE
UI Changes

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -4115,30 +4115,34 @@ p {
   width: 275px;
 } */
 
-#sponsors .sponsors-logo .gold-sponsor-logo img {
-  width: 100px;
-}
-
-#sponsors .sponsors-logo .educational-partner-logo img {
-  width: 100px;
-}
-
 #sponsors .sponsors-logo .strategic-partner-logo-common img {
-  width: 350px;
+  width: 200px;
 }
 
-#sponsors .sponsors-logo .electronic-media-partner-logo img {
-  width: 500px !important;
+#sponsors .sponsors-logo .diamond-sponsor-logo img {
+  width: 150px;
+}
+
+#sponsors .sponsors-logo .diamond-sponsor-logo-common img {
+  width: 130px;
 }
 
 #sponsors .sponsors-logo .platinum-sponsor-logo img {
   width: 250px;
 }
 
-#sponsors .sponsors-logo .partner-sponsor-logo img {
+#sponsors .sponsors-logo .gold-sponsor-logo img {
+  width: 130px;
+}
+
+#sponsors .sponsors-logo .educational-partner-logo img {
   width: 100px;
 }
 
+
+#sponsors .sponsors-logo .partner-sponsor-logo img {
+  width: 100px;
+}
 
 #sponsors .sponsors-logo .partner-logo img {
   width: 70px;
@@ -4147,7 +4151,6 @@ p {
 #sponsors .sponsors-logo .partner-logo3 img {
   width: 70px;
   height: 60px;
-
 }
 
 #sponsors .sponsors-logo .partner-logo4 img {
@@ -4157,6 +4160,10 @@ p {
 #sponsors .sponsors-logo .partner-logo5 img {
   width: 70px;
   height: 60px;
+}
+
+#sponsors .sponsors-logo .electronic-media-partner-logo img {
+  width: 500px;
 }
 
 #sponsors .sponsors-logo .afflicants-logo1 img {
@@ -4174,14 +4181,6 @@ p {
 /* only for the demo */
 #sponsors .sponsors-logo .sponsor-logo-common img {
   width: 150px;
-}
-
-#sponsors .sponsors-logo .diamond-sponsor-logo img {
-  width: 180px;
-}
-
-#sponsors .sponsors-logo .diamond-sponsor-logo-common img {
-  width: 130px;
 }
 
 .dis-btn-container {

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -4114,6 +4114,10 @@ p {
 /* #sponsors .sponsors-logo .sponsor-logo img {
   width: 275px;
 } */
+.diamond-sponsor-section{
+  margin-left: 150px;
+  margin-right: 150px;
+}
 
 #sponsors .sponsors-logo .strategic-partner-logo-common img {
   width: 200px;

--- a/src/assets/css/responsive.css
+++ b/src/assets/css/responsive.css
@@ -305,6 +305,11 @@
     grid-template-columns: repeat(3, 1fr);
   }
 
+  .diamond-sponsor-section{
+    margin-left: 0px;
+    margin-right: 0px;
+  }
+
   #sponsors .sponsors-logo .sponsor-logo img {
     margin: 10px 0px 10px 0px;
     width: 70px;

--- a/src/assets/css/responsive.css
+++ b/src/assets/css/responsive.css
@@ -318,7 +318,6 @@
 
   #sponsors .sponsors-logo .gold-sponsor-logo img {
     margin: 10px 3px 20px 3px;
-    width: 70px;
   }
 
   #sponsors .sponsors-logo .educational-partner-logo img {
@@ -371,6 +370,9 @@
     width: 55px;
   }
 
+  #sponsors .sponsors-logo .electronic-media-partner-logo img {
+    width: 250px;
+  }
 
   #dis,
   #award {
@@ -387,7 +389,6 @@
 
 #sponsors .sponsors-logo .electronic-media-partner-logo img {
   margin: 10px 3px 20px 3px;
-  width: 250px;
 }
 
 /* @media (min-width: 320px) and (max-width: 480px) {

--- a/src/pages/confirm/ConfirmPage.jsx
+++ b/src/pages/confirm/ConfirmPage.jsx
@@ -1,4 +1,4 @@
-import logo from "../../assets/img/logo-crop.png";
+import logo from "../../assets/img/NITC-Logo.png";
 
 /* eslint-disable no-unused-vars */
 import { useCallback, useEffect, useState } from "react";

--- a/src/pages/disregister/index.jsx
+++ b/src/pages/disregister/index.jsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-// import logo from "../../assets/img/logo-crop.png";
 import logo from "../../assets/img/NITC-Logo.png";
 import DisBillingDetails from "./components/DisBillingDetails";
 import DisRegisterForm from "./components/DisRegisterForm";

--- a/src/pages/home/components/Annual_Partners.jsx
+++ b/src/pages/home/components/Annual_Partners.jsx
@@ -41,7 +41,7 @@ function Annual_partners() {
                   <img src={ap_logo_2} alt="" />
                 </span>
                 <span>
-                  <img src={ap_logo_3} alt="" style={{ width: 300, height: 50 }}/>
+                  <img src={ap_logo_3} alt="" style={{ width: 250, height: 50 }}/>
                 </span>
               </div>
               <div className="col-lg-12 col-md-4 col-sm-4 text-center">

--- a/src/pages/home/components/Sponsors.jsx
+++ b/src/pages/home/components/Sponsors.jsx
@@ -76,7 +76,7 @@ function Sponsors() {
                   fontSize: "1rem",
                 }}
               >
-                Strategic partners
+                Strategic partner
               </p>
               <span className="strategic-partner-logo-common">
                 <img
@@ -94,7 +94,7 @@ function Sponsors() {
                   fontSize: "1rem",
                 }}
               >
-                Diamond sponsor
+                Diamond sponsors
               </p>
               <span className="diamond-sponsor-logo">
                 <img

--- a/src/pages/home/components/Sponsors.jsx
+++ b/src/pages/home/components/Sponsors.jsx
@@ -1,21 +1,4 @@
-// import logo_1 from "../../../assets/img/sponsors/logo-1.png";
-// import logo_2 from "../../../assets/img/sponsors/logo-2.png";
-// import logo_3 from "../../../assets/img/sponsors/mc_symbol_opt_45_3x.png";
-// import logo_4 from "../../../assets/img/sponsors/logo-4.png";
-// import logo_5 from "../../../assets/img/sponsors/logo-5.png";
-// import logo_6 from "../../../assets/img/sponsors/edp.png";
-// import logo_7 from "../../../assets/img/sponsors/gennext.png";
-// import logo_8 from "../../../assets/img/sponsors/SLTMOBITEL.png";
-// import logo_9 from "../../../assets/img/sponsors/ADL.png";
-// import logo_10 from "../../../assets/img/sponsors/Informatics.png";
-// import logo_11 from "../../../assets/img/sponsors/MITWhite.png";
-// import logo_12 from "../../../assets/img/sponsors/AllStations.png";
-// import logo_13 from "../../../assets/img/sponsors/logo-6.png";
 import TBA from "../../../assets/img/TBA.png";
-// import logo_6 from '../../../assets/img/sponsors/logo-6.png'
-// import logo_7 from '../../../assets/img/sponsors/logo-7.png'
-// import logo_8 from '../../../assets/img/sponsors/logo-8.png'
-// import logo_9 from '../../../assets/img/sponsors/logo-9.png'
 import master from '../../../assets/img/sponsors/strategicPartner/master.png';
 import dell from '../../../assets/img/sponsors/goldSponsors/DELL.png';
 import fortinet from '../../../assets/img/sponsors/goldSponsors/Fortinet.png';
@@ -80,7 +63,6 @@ function Sponsors() {
               </p>
               <span className="strategic-partner-logo-common">
                 <img
-                  style={{width:'150px'}}
                   src={master}
                   alt=""
                 />
@@ -145,29 +127,29 @@ function Sponsors() {
                 Gold sponsors
               </p>
               <div className="col-lg-12 col-md-4 col-sm-4 text-center">
-                <span className="sponsor-logo-common">
+                <span className="gold-sponsor-logo">
                   <img src={dell} alt="" />
                 </span>
-                <span className="sponsor-logo-common">
+                <span className="gold-sponsor-logo">
                   <img src={fortinet} alt="" />
                 </span>
-                <span className="sponsor-logo-common">
+                <span className="gold-sponsor-logo">
                   <img src={gennext} alt="" />
                 </span>
-                <span className="sponsor-logo-common">
+                <span className="gold-sponsor-logo">
                   <img src={JIT} alt="" />
                 </span>
               </div>
               {/* <br /> */}
 
               <div className="col-lg-12 col-md-4 col-sm-4 text-center">
-                <span className="sponsor-logo-common">
+                <span className="gold-sponsor-logo">
                   <img src={LEAFFoundation} alt="" />
                 </span>
                 {/* <span className="gold-sponsor-logo">
                   <img src={logo_6} alt="" />
                 </span> */}
-                <span className="sponsor-logo-common">
+                <span className="gold-sponsor-logo">
                   <img src={MIT} alt="" />
                 </span>
                 {/* <span className="sponsor-logo-common">

--- a/src/pages/home/components/Sponsors.jsx
+++ b/src/pages/home/components/Sponsors.jsx
@@ -67,37 +67,39 @@ function Sponsors() {
                   alt=""
                 />
               </span>
-              <p
-                style={{
-                  fontWeight: "600",
-                  textAlign: "center",
-                  marginTop: "20px",
-                  marginBottom: "20px",
-                  fontSize: "1rem",
-                }}
-              >
-                Diamond sponsors
-              </p>
-              <span className="diamond-sponsor-logo">
-                <img
-                  src={DMS}
-                  style={{marginBottom:'30px'}}
-                  alt=""
-                />
-              </span>
-              <div className="col-lg-12 col-md-4 col-sm-4 text-center">
-                <span className="diamond-sponsor-logo-common">
-                  <img src={Asset6} alt="" />
+              <div className="diamond-sponsor-section">
+                <p
+                  style={{
+                    fontWeight: "600",
+                    textAlign: "center",
+                    marginTop: "20px",
+                    marginBottom: "20px",
+                    fontSize: "1rem",
+                  }}
+                >
+                  Diamond sponsors
+                </p>
+                <span className="diamond-sponsor-logo">
+                  <img
+                    src={DMS}
+                    style={{marginBottom:'30px'}}
+                    alt=""
+                  />
                 </span>
-                <span className="diamond-sponsor-logo-common">
-                  <img src={SafeProject} alt="" />
-                </span>
-                <span className="diamond-sponsor-logo-common">
-                  <img src={Sanfer} alt="" />
-                </span>
-                <span className="diamond-sponsor-logo-common">
-                  <img src={Orin} alt="" />
-                </span>
+                <div className="col-lg-12 col-md-4 col-sm-4 text-center border">
+                  <span className="diamond-sponsor-logo-common">
+                    <img src={Asset6} alt="" />
+                  </span>
+                  <span className="diamond-sponsor-logo-common">
+                    <img src={SafeProject} alt="" />
+                  </span>
+                  <span className="diamond-sponsor-logo-common">
+                    <img src={Sanfer} alt="" />
+                  </span>
+                  <span className="diamond-sponsor-logo-common">
+                    <img src={Orin} alt="" />
+                  </span>
+                </div>
               </div>
               <p
                 style={{

--- a/src/pages/home/index.jsx
+++ b/src/pages/home/index.jsx
@@ -9,7 +9,7 @@ import DIS from "./components/DIS";
 // import Introduction from "./components/Introduction";
 import Awards from "./components/Awards";
 import About_CSSL from "./components/About_CSSL";
-import Digital_economy from "./components/Digital_Economy";
+// import Digital_economy from "./components/Digital_Economy";
 // import Counter_area from "./components/Counter_area";
 // import Event_gallery from "./components/Event_gallery";
 // import CSSL_digital_investment_submit from "./components/CSSL_digital_investment_submit";
@@ -19,9 +19,9 @@ import Gallery from "./components/Gallery";
 import Ticket_pricing from "./components/Ticket_pricing";
 import Sponsors from "./components/Sponsors";
 import National_partners from "./components/National_partners";
-import Annual_partners from "./components/Annual_Partners";
 import Partners from "./components/Partners";
 import Afflicants from "./components/Afflicants";
+import Annual_partners from "./components/Annual_Partners";
 import Map from "./components/Map";
 import Footer from "./components/Footer";
 // import Speakers from "./components/Speakers";
@@ -39,7 +39,7 @@ function index() {
       <Awards />
       {/* <Introduction /> */}
       <DIS />
-      <Digital_economy />
+      {/* <Digital_economy /> */}
       {/* <Speakers/> */}
       {/* <CSSL_digital_investment_submit /> */}
       {/* <CSSL_awards />
@@ -55,6 +55,7 @@ function index() {
       <Sponsors />
       <Partners />
       <Afflicants />
+      <Annual_partners />
       <Map />
       <Footer />
     </>

--- a/src/pages/home/index.jsx
+++ b/src/pages/home/index.jsx
@@ -51,7 +51,6 @@ function index() {
       <Ticket_pricing />
       <About_CSSL />
       <National_partners />
-      <Annual_partners />
       <Sponsors />
       <Partners />
       <Afflicants />

--- a/src/pages/register/components/BillingDetails.jsx
+++ b/src/pages/register/components/BillingDetails.jsx
@@ -425,7 +425,7 @@ function BillingDetails({ isMember, setisMember, memberId, setMemberId, setIsChe
 
                         <div className="form-footer">
                             <p className="star-before">For members of professional bodies (BCS, ISACA, IESL, IET,
-                                IEEE, ACM, ACS, SLASSCOM, and FITTIS), an exclusive discount awaits! Contact
+                                IEEE, ACM, and ACS), an exclusive discount awaits! Contact
                                 your secretariat to claim this benefit.</p>
                         </div>
                         <div className="form-group d-flex justify-content-end">

--- a/src/pages/register/index.jsx
+++ b/src/pages/register/index.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import logo from "../../assets/img/logo-crop.png";
+import logo from "../../assets/img/NITC-Logo.png";
 
 import BillingDetails from "./components/BillingDetails";
 import RegisterForm from "./components/RegisterForm";


### PR DESCRIPTION
**Description**

Change the existing UI based on the following requirements:

- Move CSSL to the "Annual Partners" section under OUR Affiliations.
- Update the logo to NITC 2024.
- Remove SLASSCOM and FITTIS from the payment page.
- Remove the DigiEcon section.
- Change "Strategic Partners" to "Diamond Sponsors" (add an "S" to make it plural).

**Demo**

Before:
<img width="796" alt="image" src="https://github.com/user-attachments/assets/6ac66558-8eb4-4b85-ba19-557d81767841">
<img width="899" alt="sponsor-2-1" src="https://github.com/user-attachments/assets/84dc21d9-0f49-4d59-9171-f6f66521d0af">
<img width="864" alt="sponsor-2-2" src="https://github.com/user-attachments/assets/470645e9-3431-4315-add5-07d55934aad9">
<img width="749" alt="sponsor-2-3" src="https://github.com/user-attachments/assets/44de5cd0-2f53-490c-b0c5-765a57e4bb0c">


After:
<img width="874" alt="image" src="https://github.com/user-attachments/assets/672a7ba8-5bbb-48db-a1fe-c4d6711e553d">
<img width="951" alt="sponsor-2" src="https://github.com/user-attachments/assets/7cfa744e-c86f-423d-80b8-009ebf579876">
<img width="868" alt="sponsor-3" src="https://github.com/user-attachments/assets/8049ec00-dfbc-48e8-a1ec-8601343183d3">
<img width="923" alt="sponsor-1" src="https://github.com/user-attachments/assets/56aea79c-115b-46b4-b53a-3ba9f0612f26">


