### PR TITLE
partners logo size changes

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -4182,6 +4182,10 @@ p {
   width: 80px;
 }
 
+#sponsors .sponsors-logo .annual-partner-logo img {
+  width: 70px;
+}
+
 /* only for the demo */
 #sponsors .sponsors-logo .sponsor-logo-common img {
   width: 150px;

--- a/src/pages/home/components/Annual_Partners.jsx
+++ b/src/pages/home/components/Annual_Partners.jsx
@@ -34,24 +34,24 @@ function Annual_partners() {
           <div className="col-lg-12">
             <div className="sponsors-logo">
               <div className="col-lg-12 col-md-4 col-sm-4 text-center">
-                <span className="sponsor-logo-common">
-									<img src={ap_logo_1} alt="" style={{ width: 100, height: 30 }}/>
+                <span className="annual-partner-logo">
+									<img src={ap_logo_1} alt="" style={{ height: 17 }}/>
                 </span>
-                <span className="sponsor-logo-common">
+                <span className="annual-partner-logo">
                   <img src={ap_logo_2} alt="" />
                 </span>
                 <span>
-                  <img src={ap_logo_3} alt="" style={{ width: 250, height: 50 }}/>
+                  <img src={ap_logo_3} alt="" style={{ width: 200, height: 45 }}/>
                 </span>
               </div>
               <div className="col-lg-12 col-md-4 col-sm-4 text-center">
-                <span className="sponsor-logo-common">
+                <span className="annual-partner-logo">
                   <img src={ap_logo_4} alt="" />
                 </span>
-                <span className="sponsor-logo-common">
+                <span className="annual-partner-logo">
                   <img src={ap_logo_5} alt="" />
                 </span>
-                <span className="sponsor-logo-common">
+                <span className="annual-partner-logo">
                   <img src={ap_logo_6} alt="" />
                 </span>
               </div>


### PR DESCRIPTION
Description:
Resize the CSSL annual partner logos.

Demo:

Before
<img width="725" alt="image" src="https://github.com/user-attachments/assets/9e08e29e-cb11-4784-aeee-f08ef5bdddf4">

After
<img width="628" alt="image" src="https://github.com/user-attachments/assets/58fcba93-5b14-4a20-9104-0a2372ee13e5">
